### PR TITLE
Update index.html to add the add points link

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -73,7 +73,7 @@
                 {% for batch in batches %}
                 <div class="batch-card">
                     <div class="batch-header">
-                        <div class="batch-title"><a href="/edit_spots/{{ batch.batch_id }}" style="color: inherit; text-decoration: none;">{{ batch.batch_id }}</a></div>
+                        <div class="batch-title"><a href="/edit_spots/{{ batch.batch_id }}" style="color: inherit; text-decoration: none;">{{ batch.batch_id }}</a><a href="/label_hotspots.html/{{ batch.batch_id}}" style="text-decoration: none;"> _ Add points</a></div>
                         <div class="batch-date">{{ batch.timestamp[:19] if batch.timestamp else 'N/A' }}</div>
                     </div>
                     <div class="batch-stats">


### PR DESCRIPTION
Adds a new "Add points" link next to the batch ID on the index page to allow labeling hotspots directly from the batch listing.